### PR TITLE
[TEST] ComplianceCow Auto-Deactivate Access Keys Validation Run

### DIFF
--- a/UserDataFile/iamusers/arjun_k/lokesk/deactivate/exempt/lokesh_exempt.yaml
+++ b/UserDataFile/iamusers/arjun_k/lokesk/deactivate/exempt/lokesh_exempt.yaml
@@ -8,12 +8,12 @@ Name: lokesh_exempt
 Path: /
 Owner: arjun.k@continube.com
 Policies: []
-ActiveKeys:
+ActiveKeys: []
+DeactivatedKeys:
   - Name: TestAWSAccessKeyTwo
     LegacyAccessKeyId: AKIADSTT11EUF6PNQDVS
     OwnerRoles:
-      - arn:aws:iam::066744120626:user/harish_j 
-DeactivatedKeys: []
+      - arn:aws:iam::066744120626:user/harish_j
 DeletedKeys: []
 ResourceTags: []
 


### PR DESCRIPTION
This is a test pull request generated by the ComplianceCow team to validate GitHub token permissions and the end-to-end Stale IAM User workflow.
It moves access keys from `ActiveKeys` to `DeactivatedKeys` based on the latest data from AWS S3.

https://manuals-v2.prod.netflix.net/infrasec/main/pipelines/staleiamuser-runbook.md#overview

**Files Updated:** 1

- `UserDataFile/iamusers/arjun_k/lokesk/deactivate/exempt/lokesh_exempt.yaml`